### PR TITLE
Sg16submit upgrade

### DIFF
--- a/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
+++ b/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
@@ -16,6 +16,7 @@
 # requeing is also disabled for TD-DFT and TDA-DFT since # restart does not work with those methods
 #
 # To Do:
+# use printf to reduce the amount of lines needed for simple text output
 # enable requeuing for RSHopt
 # add command option to print last x number of submitted jobs (filename jobid)
 # improve formatting of text sent to log fle (on going)
@@ -441,7 +442,8 @@ if [ "${RESTART}" = "TRUE" ]; then
 else
 	TIMEOUT=0
 fi
-
+# use echo "-----------------------------------------" ; printf "%-19s| ${BOLDTEXT}\n" "${TEXT[@]}" ; echo "-----------------------------------------" or similar for text formatting
+# where BOLDTEXT=${tput bold}%s${tput sgr0} and TEXT=(an array of the text to be displayed)
 # check with the user if values are as desired
 printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
 echo "The calculation on ${COM_FULLNAME} will be submitted with the following values:"
@@ -473,6 +475,7 @@ while : ;do
 done
 
 # Submit the job
+# use printf to print this in one shot. That way a temp file is not needed
 echo >> ${LOG}
 echo "<submission>" >> ${LOG}
 echo "	type: new submission" >> ${LOG}

--- a/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
+++ b/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
@@ -21,6 +21,7 @@
 # improve formatting of text sent to log fle (on going)
 # Write all log output to temp file (use TEMP=$( mktemp )) and then write to log all at once (https://unix.stackexchange.com/questions/181937/how-create-a-temporary-file-in-shell-script)
 # recognize what kind of calculation has been run and if the job completes summarize important info (ex. if structure if converged for opt and freq)
+# add text formatting to conformation output
 ######
 
 ### STUFF ###
@@ -441,15 +442,15 @@ else
 	TIMEOUT=0
 fi
 
-# check with user if values are as desired
-echo
+# check with the user if values are as desired
+printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
 echo "The calculation on ${COM_FULLNAME} will be submitted with the following values:"
-echo "Email: ${EMAIL}"
-echo "Walltime: ${TIME}"
-echo "Cores: ${NCPUS}"
-echo "Compensated Memory: ${MEM_VAL}${MEM_UNIT}"
-echo "Run script: ${SCRIPT}"
-echo "Requeue: ${RESTART}"
+echo "Email: $(tput bold)${EMAIL}$(tput sgr0)"
+echo "Walltime: $(tput Bold)${TIME}$(tput sgr0)"
+echo "Cores: $(tput bold)${NCPUS}$(tput sgr0)"
+echo "Compensated Memory: $(tput bold)${MEM_VAL}${MEM_UNIT}$(tput sgr0)"
+echo "Run script: $(tput bold)${SCRIPT}$(tput sgr0)"
+echo "Requeue: $(tput bold)${RESTART}$(tput sgr0)"
 echo
 echo -n "Do you want to submit with these values? [y/n]: "
 while : ;do 

--- a/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
+++ b/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
@@ -48,9 +48,6 @@ V=$( module spider gaussian | grep gaussian/ )
 VL=$( echo "$V" | wc -l ) 
 echo "$V" | head -n $(( ${VL} - 1 )) 
 
-#Check for NImag (complicated because the key word can be split over multiple lines and each newline in the block it is in starts with a space)
-
-
 ### EXIT CONDITIONS ###
 ER_COM_FILE=1
 ER_TIME_FORMAT=2

--- a/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
+++ b/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
@@ -22,7 +22,7 @@
 # Write all log output to temp file (use TEMP=$( mktemp )) and then write to log all at once (https://unix.stackexchange.com/questions/181937/how-create-a-temporary-file-in-shell-script)
 # recognize what kind of calculation has been run and if the job completes summarize important info (ex. if structure if converged for opt and freq)
 # add text formatting to conformation output
-######
+# use if [[ -z $( tail -n 2 <file>.com ) ]] ; then <stuff> ; fi to check if there are at least two blank lines at the end of the com file. If there isnt add two blank lines to com file before submission.
 
 ### STUFF ###
 SCRIPT_CALC=G16Calc-1.7.4.sh

--- a/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
+++ b/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
@@ -33,17 +33,23 @@ SCRIPT_FULLNAME=$( realpath $BASH_SOURCE )
 GAUSSIAN_VERSION=
 ######
 
-# this should probably be moved
+# this should be moved
 # gaussian version check
-# 	if $( module spider gaussian | grep -q g16.c01 ) ; then echo "version exists" ; else echo "version not found" ; fi 
-# gaussian version latest
-# G=$( module spider gaussian | grep "gaussian/" | tail -n 2 | head -n 1 )  && G=${G// /}
-# available versions
-# V=$( module spider gaussian | grep gaussian/ ) 
-# VL=$( echo "$V" | wc -l ) 
-# echo "$V" | head -n $(( ${VL} - 1 )) 
-# Check for NImag (complicated because the key word can be split over multiple lines and each newline in the block it is in starts with a space)
-# for F in DTA POZP DMAP HMAT ; do echo ${F}-BFC-freq2-re.log ; cat ${F}-BFC-freq2-re.log | tr -d '\n' | tr -d ' ' | grep -io "NImag=." ; done 
+if $( module spider gaussian | grep -q g16.c01 ) ; then 
+	echo "version exists"
+else 
+	echo "version not found"
+fi 
+#gaussian version latest
+#im honestly not sure what I was trying to do here
+G=$( module spider gaussian | grep "gaussian/" | tail -n 2 | head -n 1 )  && G=${G// /}
+available versions
+V=$( module spider gaussian | grep gaussian/ ) 
+VL=$( echo "$V" | wc -l ) 
+echo "$V" | head -n $(( ${VL} - 1 )) 
+
+Check for NImag (complicated because the key word can be split over multiple lines and each newline in the block it is in starts with a space)
+for F in DTA POZP DMAP HMAT ; do echo ${F}-BFC-freq2-re.log ; cat ${F}-BFC-freq2-re.log | tr -d '\n' | tr -d ' ' | grep -io "NImag=." ; done 
 
 ### EXIT CONDITIONS ###
 ER_COM_FILE=1

--- a/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
+++ b/DFT_Scripts/sg16submit-Mk0.9.3.7.sh
@@ -20,7 +20,7 @@
 # add command option to print last x number of submitted jobs (filename jobid)
 # improve formatting of text sent to log fle (on going)
 # Write all log output to temp file (use TEMP=$( mktemp )) and then write to log all at once (https://unix.stackexchange.com/questions/181937/how-create-a-temporary-file-in-shell-script)
-# recognize what kind of calculation has been run and if the fob completes summarize important info (ex. if structure if converged for opt and freq)
+# recognize what kind of calculation has been run and if the job completes summarize important info (ex. if structure if converged for opt and freq)
 ######
 
 ### STUFF ###
@@ -39,7 +39,8 @@ if $( module spider gaussian | grep -q g16.c01 ) ; then
 	echo "version exists"
 else 
 	echo "version not found"
-fi 
+fi
+
 #gaussian version latest
 #im honestly not sure what I was trying to do here
 G=$( module spider gaussian | grep "gaussian/" | tail -n 2 | head -n 1 )  && G=${G// /}
@@ -210,7 +211,7 @@ NCPUS=${NCPUS//[!0-9]/}
 # route stuff. will have to think over this
 ROUTE=$( grep \# ${1} | head -n 1 )
 
-# use below for error checking. rest is not needed
+# use below for error checking. Rest is not needed
 	echo "ERROR: incorrect memory units specified in .com file. Must use MB or GB"
 	exit ${ER_MEM_UNIT}
 }

--- a/DFT_Scripts_Alpha_Versions/sg16submit-Mk0.9.4.0.sh
+++ b/DFT_Scripts_Alpha_Versions/sg16submit-Mk0.9.4.0.sh
@@ -207,9 +207,6 @@ ROUTE=$( grep \# ${1} | head -n 1 )
 # use below for error checking. rest is not needed
 	echo "ERROR: incorrect memory units specified in .com file. Must use MB or GB"
 	exit ${ER_MEM_UNIT}
-fi
-
-
 }
 
 


### PR DESCRIPTION
upgrading sg16submit with a better way of getting information from the com file. Better ability to restart calculations will also be implemented (opt and freq use a different way then TD). This will allow for an extension to ORCA .inp files as well.
- [ ] detect line endings and convert if required
- [ ] allow files with spaces to be used or error out if spaces are present
- [ ] check if at least two blank lines are at the end of the .com file.
  - [ ] add if not present
- [ ] output to a temp file then copy all at once to log file
- [ ] make update function for the log file
- [ ] if %oldchk is used make sure the file is present
- [ ] add warning when .com .rwf and .com file names don't match
- [ ] make restart intelligent-ish
  - [ ] enable restart of rshopt
  - [ ] use TD=(restart) for TD or TDA calculations
- [ ] incorporate RSHopt script
  - [ ] write only if an RSH optimization is requested
- [ ] add relevant data to output
  - [ ] add a timing feature so that if a very large log file is generated this will exit after a set amount of time
  - [ ] make it so that values are only collected if a relevant calculation is run
  - [x] NImag for freq calculations
  - [ ] non-optimized geometry
  - [ ] optimization based on negligible forces
- [ ] make it easy to change gaussian version used
- [ ] give useful feedback regarding submission
  - [ ] memory suggestion so that the cpu:memory ratio is appropriate for the different node configurations
  - [ ] use of spaces in file names (suggest they are removed instead of just removing them or exiting with an error)
  - [ ] if the proper line endings are used
  - [ ] include a rwf file name
- [ ] check over using shellcheck
- [ ] error test